### PR TITLE
Add configuration sample and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Mune Ordering System
+
+This repository contains a simple PHP-based menu and order management system. The project expects a MySQL database and a configuration file in `config/database.php`.
+
+## Setup
+1. Copy or edit `config/database.php` and set your database credentials or export the environment variables `DB_HOST`, `DB_USER`, `DB_PASS`, and `DB_NAME`.
+2. Ensure PHP 8.3 or newer is installed on the server. The `.htaccess` file sets the PHP handler when using cPanel.
+3. Import the required database schema (not included) and make sure tables referenced in the code exist.
+4. Access `menu.php?slug=YOUR_SLUG` in the browser to view the menu for a restaurant.
+
+## Files
+- `menu.php` – displays the restaurant menu and allows adding items to a cart.
+- `checkout.php` – shows the order summary and collects customer details.
+- `place_order.php` – processes the order and writes it to the database.
+- `order_confirmation.php` – thanks the user after placing an order.
+- `test_connection.php` – quick script to test the MySQL connection.
+
+All pages are written in Arabic and expect UTF-8 encoding.

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,21 @@
+<?php
+// Sample database configuration file
+// Use environment variables or change the values below to match your database
+
+// Database credentials
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_USER', getenv('DB_USER') ?: 'db_user');
+define('DB_PASS', getenv('DB_PASS') ?: 'db_password');
+define('DB_NAME', getenv('DB_NAME') ?: 'db_name');
+
+// Create connection
+$conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+
+// Check connection
+if ($conn->connect_error) {
+    die('Connection failed: ' . $conn->connect_error);
+}
+
+// Use UTF-8 encoding
+$conn->set_charset('utf8mb4');
+?>


### PR DESCRIPTION
## Summary
- add example MySQL connection file in `config/database.php`
- document setup and file descriptions in new README

## Testing
- `php -l config/database.php`
- `php -l menu.php`
- `php -l checkout.php`
- `php -l place_order.php`
- `php -l order_confirmation.php`
- `php -l test_connection.php`


------
https://chatgpt.com/codex/tasks/task_e_6842f50c92e4832ca7bbec7757ae5404