### PR TITLE
Secure admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Mune
+
+This project requires administrator credentials for accessing the admin panel. Credentials are loaded from environment variables at runtime or can be set by editing `config/admin.php`.
+
+## Setting credentials via environment variables
+
+Set the following variables before running the application:
+
+```bash
+export ADMIN_USER="your_admin_username"
+export ADMIN_PASS_HASH="$(php -r "echo password_hash('your_password', PASSWORD_DEFAULT);")"
+```
+
+`ADMIN_PASS_HASH` must contain a hash generated with `password_hash()`.
+
+## Configuration file (optional)
+
+If environment variables are not used, you can create or edit `config/admin.php` to return an array with `username` and `password_hash` keys. Example:
+
+```php
+<?php
+return [
+    'username' => 'admin',
+    'password_hash' => '$2y$10$examplehashhere',
+];
+```
+

--- a/admin/login.php
+++ b/admin/login.php
@@ -11,10 +11,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = $_POST['username'] ?? '';
     $password = $_POST['password'] ?? '';
 
-    $adminUser = getenv('ADMIN_USER') ?: 'admin';
-    $adminPass = getenv('ADMIN_PASS') ?: 'admin123';
+    $config = include __DIR__ . '/../config/admin.php';
+    $adminUser = $config['username'] ?? null;
+    $adminHash = $config['password_hash'] ?? null;
 
-    if ($username === $adminUser && $password === $adminPass) {
+    if (!$adminUser || !$adminHash) {
+        $error = 'لم يتم ضبط بيانات تسجيل الدخول.';
+    } elseif ($username === $adminUser && password_verify($password, $adminHash)) {
         $_SESSION['admin_logged_in'] = true;
         header('Location: index.php');
         exit();

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'username' => getenv('ADMIN_USER') ?: null,
+    'password_hash' => getenv('ADMIN_PASS_HASH') ?: null,
+];
+?>


### PR DESCRIPTION
## Summary
- remove default admin username/password and read from config
- add `config/admin.php` to load credentials from env vars
- document setting up admin credentials

## Testing
- `php -l admin/login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68442a46dbc0832c8b4e776d8fad877b